### PR TITLE
Passing data to add child vc

### DIFF
--- a/Story Squad/Story Squad.xcodeproj/xcuserdata/macbook.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Story Squad/Story Squad.xcodeproj/xcuserdata/macbook.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,7 +7,7 @@
 		<key>Story Squad.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>3</integer>
+			<integer>0</integer>
 		</dict>
 	</dict>
 </dict>

--- a/Story Squad/Story Squad.xcodeproj/xcuserdata/macbook.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Story Squad/Story Squad.xcodeproj/xcuserdata/macbook.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,7 +7,7 @@
 		<key>Story Squad.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>3</integer>
 		</dict>
 	</dict>
 </dict>

--- a/Story Squad/Story Squad/Helper/StringKeys.swift
+++ b/Story Squad/Story Squad/Helper/StringKeys.swift
@@ -11,4 +11,9 @@ import Foundation
 extension String {
 
 	static var addChildSegue = "AddChild"
+    
+    // Notification Pattern Keys
+    static var passDataForParentString = "co.lambda.pasDataForParent"
+    static var passDataForChildString = "co.lambda.pasDataForChild"
+    
 }

--- a/Story Squad/Story Squad/Storyboards/Dashboard.storyboard
+++ b/Story Squad/Story Squad/Storyboards/Dashboard.storyboard
@@ -148,7 +148,7 @@
                                                     </userDefinedRuntimeAttribute>
                                                 </userDefinedRuntimeAttributes>
                                                 <connections>
-                                                    <segue destination="aN3-D4-b1h" kind="show" id="1zG-y0-S6V"/>
+                                                    <segue destination="aN3-D4-b1h" kind="show" identifier="AddChildSegue" id="1zG-y0-S6V"/>
                                                 </connections>
                                             </button>
                                         </subviews>

--- a/Story Squad/Story Squad/View Controllers/DashboardViewController.swift
+++ b/Story Squad/Story Squad/View Controllers/DashboardViewController.swift
@@ -63,43 +63,12 @@ class DashboardViewController: UIViewController {
         super.viewDidLoad()
         
         updateViews()
-        createObservers()
     }
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
         childrenProfilesCollectionView.reloadData()
-    }
-    
-    // Removing Notifications after we are done with them
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-    
-    func createObservers() {
-        
-        // When Parent User
-        NotificationCenter.default.addObserver(self, selector: #selector(DashboardViewController.updateData(notification:)), name: dataForParentNotification, object: nil)
-        
-        // When Child User
-        NotificationCenter.default.addObserver(self, selector: #selector(DashboardViewController.updateData(notification:)), name: dataForChildNotification, object: nil)
-        
-    }
-    
-    @objc func updateData(notification: Notification) {
-        
-        print("Dasboard has been been nofified!")
-        
-        let isParent = notification.name == dataForParentNotification
-        
-        if isParent {
-            
-        } else {
-            
-        }
-        
-        
     }
     
     // MARK: - Hambuerger Menu
@@ -146,9 +115,6 @@ class DashboardViewController: UIViewController {
     
     private func updateViews() {
         
-        // MARK: - Listening for Notifications
-        
-        
         let pumkinStrokeAttribute = NSAttributedString(string: storySquadLabel.text!, attributes: sqLabelStrokeAttributes)
         
         storySquadLabel.attributedText = pumkinStrokeAttribute
@@ -165,7 +131,7 @@ class DashboardViewController: UIViewController {
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         
-        // Ask for Parent PIN for adding a new Child
+        // Pass data to AddChildVc
         if segue.identifier == "AddChildSegue" {
             guard let addChildVC = segue.destination as? AddChildViewController  else { return }
             addChildVC.parentUser = self.parentUser

--- a/Story Squad/Story Squad/View Controllers/DashboardViewController.swift
+++ b/Story Squad/Story Squad/View Controllers/DashboardViewController.swift
@@ -20,6 +20,9 @@ class DashboardViewController: UIViewController {
     var childUser: Child?
     
     let transition = SlideInTransition()
+    let dataForParentNotification = Notification.Name(rawValue: .passDataForParentString)
+    let dataForChildNotification = Notification.Name(rawValue: .passDataForChildString)
+    
     let sqLabelStrokeAttributes: [NSAttributedString.Key: Any] = [
         .strokeColor: UIColor(red: 1, green: 0.427, blue: 0.227, alpha: 1),
         .strokeWidth: -3.5
@@ -60,12 +63,43 @@ class DashboardViewController: UIViewController {
         super.viewDidLoad()
         
         updateViews()
+        createObservers()
     }
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
         childrenProfilesCollectionView.reloadData()
+    }
+    
+    // Removing Notifications after we are done with them
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+    
+    func createObservers() {
+        
+        // When Parent User
+        NotificationCenter.default.addObserver(self, selector: #selector(DashboardViewController.updateData(notification:)), name: dataForParentNotification, object: nil)
+        
+        // When Child User
+        NotificationCenter.default.addObserver(self, selector: #selector(DashboardViewController.updateData(notification:)), name: dataForChildNotification, object: nil)
+        
+    }
+    
+    @objc func updateData(notification: Notification) {
+        
+        print("Dasboard has been been nofified!")
+        
+        let isParent = notification.name == dataForParentNotification
+        
+        if isParent {
+            
+        } else {
+            
+        }
+        
+        
     }
     
     // MARK: - Hambuerger Menu
@@ -111,6 +145,9 @@ class DashboardViewController: UIViewController {
     }
     
     private func updateViews() {
+        
+        // MARK: - Listening for Notifications
+        
         
         let pumkinStrokeAttribute = NSAttributedString(string: storySquadLabel.text!, attributes: sqLabelStrokeAttributes)
         

--- a/Story Squad/Story Squad/View Controllers/DashboardViewController.swift
+++ b/Story Squad/Story Squad/View Controllers/DashboardViewController.swift
@@ -166,10 +166,10 @@ class DashboardViewController: UIViewController {
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         
         // Ask for Parent PIN for adding a new Child
-        if segue.identifier == "AddChildSegueToPin" {
-//            guard let addChildSegueToPinVC = segue.destination as? AddChildParentPinViewController  else { return }
-//            addChildSegueToPinVC.parentUser = self.parentUser
-//            addChildSegueToPinVC.networkingController = self.networkingController
+        if segue.identifier == "AddChildSegue" {
+            guard let addChildVC = segue.destination as? AddChildViewController  else { return }
+            addChildVC.parentUser = self.parentUser
+            addChildVC.networkingController = self.networkingController
             
             // Ask for Child PIN to display Child's Profile
         } else if segue.identifier == "ShowChildPinVCSegue" {

--- a/Story Squad/Story Squad/View Controllers/ParentInfoViewController.swift
+++ b/Story Squad/Story Squad/View Controllers/ParentInfoViewController.swift
@@ -41,23 +41,22 @@ class ParentInfoViewController: UIViewController {
             let email = emailTextField.text,
             let password = passwordTextField.text,
             let confirmPW = confirmPWTextField.text,
-            let pin = pinTextField.text,
+//            let pin = pinTextField.text,
             !name.isEmpty,
             !email.isEmpty,
             !password.isEmpty,
-            !confirmPW.isEmpty,
-            !pin.isEmpty else { return }
+            !confirmPW.isEmpty else { return }
+//            !pin.isEmpty else { return }
         
-        // MARK: - Print Statements
-        print(name)
-        print(email)
-        print(password)
-        print(pin)
+        let temporaryPIN: Int16 = 0000
         
-        let pinInt = Int16(pin)
-        
-        let parent = networkingController.createParent(name: name, email: email, password: password, pin: pinInt!, context: CoreDataStack.shared.mainContext)
+        let parent = networkingController.createParent(name: name, email: email, password: password, pin: temporaryPIN, context: CoreDataStack.shared.mainContext)
         self.parentUser = parent
+        
+        // MARK: - Sending data through Notification
+        let parentDataNotificationName = Notification.Name(rawValue: .passDataForParentString)
+        NotificationCenter.default.post(name: parentDataNotificationName, object: nil, userInfo: nil)
+        
         performSegue(withIdentifier: "ShowTabBarSegue", sender: self)
     }
     
@@ -79,15 +78,14 @@ class ParentInfoViewController: UIViewController {
             
 			//swiftlint:disable force_cast
             let navVC = tabBarController?.viewControllers![1] as! UINavigationController
+            let dashboardVC = navVC.topViewController as! DashboardViewController
+            dashboardVC.parentUser = self.parentUser
+            dashboardVC.networkingController = self.networkingController
             
 //            let mainTabBarVC = navVC.topViewController as! MainTabBarController
 //            mainTabBarVC.parentUser = self.parentUser
 //            mainTabBarVC.networkingController = self.networkingController
-            
-           let dashboardVC = navVC.topViewController as? DashboardViewController
-
-            dashboardVC?.parentUser = self.parentUser
-            dashboardVC?.networkingController = self.networkingController
+            //////////////////
             
 //            let settingsVC = navVC.topViewController as? SettingsParentPinViewController
 //

--- a/Story Squad/Story Squad/View Controllers/ParentInfoViewController.swift
+++ b/Story Squad/Story Squad/View Controllers/ParentInfoViewController.swift
@@ -82,11 +82,6 @@ class ParentInfoViewController: UIViewController {
             dashboardVC.parentUser = self.parentUser
             dashboardVC.networkingController = self.networkingController
             
-//            let mainTabBarVC = navVC.topViewController as! MainTabBarController
-//            mainTabBarVC.parentUser = self.parentUser
-//            mainTabBarVC.networkingController = self.networkingController
-            //////////////////
-            
 //            let settingsVC = navVC.topViewController as? SettingsParentPinViewController
 //
 //            settingsVC?.parentUser = self.parentUser


### PR DESCRIPTION
# Description
Data passes through segues successfully, so the addChild Functionality works again.

Fixes # (issue)
Parent Object and Networking Controller successfully pass from ParentSignupVC through Dashboard and finally to the AddChildVC. 
A Child Object can also be created, added to a Parent and saved in CoreData

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [ ] Complete, tested, ready to review and merge
- [x] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

- [ ] Test A
- [ ] Test B

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
