### PR TITLE
Login fetching Parent from CD

### DIFF
--- a/Story Squad/Story Squad/Networking/NetworkingController.swift
+++ b/Story Squad/Story Squad/Networking/NetworkingController.swift
@@ -227,7 +227,13 @@ class NetworkingController {
                 // Fetching Parent from CoreData and setting it as self.ParenUser
                 _ = self.fetchParentFromCDWithEmail(email: email)
                 
-                // TODO: Make sure you create a new Parent if couldn't fetch from CoreData
+                if self.parentUser == nil {
+                    // Create Parent in CoreData
+                    let temporaryID = UUID().uuidString
+                    let temporaryPIN = Int16.random(in: 0..<1_000)
+                    let parent = self.createParent(name: " ", id: temporaryID, email: email, password: password, pin: temporaryPIN, context: CoreDataStack.shared.mainContext)
+                    self.parentUser = parent
+                }
                 
                 // Return the Bearer
                 completion(.success(self.bearer))

--- a/Story Squad/Story Squad/View Controllers/LogInViewController.swift
+++ b/Story Squad/Story Squad/View Controllers/LogInViewController.swift
@@ -92,6 +92,10 @@ class LogInViewController: UIViewController {
     }
     
     func updateViews() {
+        
+        // Hide NavigationController Bar
+        navigationController?.navigationBar.isHidden = true
+        
         // TODO: Remove when functionality is there for Forgot Password
         forgotPasswordButton.alpha = 0
         


### PR DESCRIPTION
# Description
Creates a new Parent after Logging in if Parent is not in CoreData

Fixes # (issue)
Creates a new Parent Object after Logging in with credentials used to Signup on a different device.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [ ] Complete, tested, ready to review and merge
- [x] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

- [ ] Test A
- [ ] Test B

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
