### PR TITLE
Bug Fix. User can't continue to DashboardVC if parentUser is not set.

### DIFF
--- a/Story Squad/Story Squad/Networking/NetworkingController.swift
+++ b/Story Squad/Story Squad/Networking/NetworkingController.swift
@@ -27,8 +27,8 @@ class NetworkingController {
         //        func signupParent(email: String, password: String, termsOfService: Bool,  completion: @escaping(Result<ParentRepresentation?, NetworkingError>) -> Void) {
         
         let headers = [
-            "content-type": "application/json",
-            "authorization": "Bearer undefined"
+            "Content-Type": "application/json",
+            "Authorization": "Bearer undefined"
         ]
         let json = """
         {
@@ -175,7 +175,7 @@ class NetworkingController {
         
         var request = URLRequest(url: registerURL)
         request.httpMethod = HTTPMethod.post.rawValue
-        request.allHTTPHeaderFields = ["content-type": "application/json"]
+        request.allHTTPHeaderFields = ["Content-Type": "application/json"]
         
         let json = """
         {

--- a/Story Squad/Story Squad/View Controllers/LogInViewController.swift
+++ b/Story Squad/Story Squad/View Controllers/LogInViewController.swift
@@ -45,7 +45,7 @@ class LogInViewController: UIViewController {
         let error = validateFields()
         
         if error != nil {
-            showErrorAlert(errorMessage: error!)
+            showErrorAlert(errorTitle: "Sorry", errorMessage: error!)
         } else {
             
             // Clean version of data entry
@@ -67,13 +67,13 @@ class LogInViewController: UIViewController {
                             self.parentUser = parent
                             self.performSegue(withIdentifier: "ShowTabBarFromLoginSegue", sender: self)
                         } else {
-                            self.showErrorAlert(errorMessage: "Timed out. Please try again")
+                            self.showErrorAlert(errorTitle: "Oops!", errorMessage: "Couldn't get all necessary data. Please try again")
                             NSLog("Couldn't get response from server.")
                         }
                     }
                 } catch {
                     DispatchQueue.main.async {
-                        self.showErrorAlert(errorMessage: "Unsuccessful Login. Please try again.")
+                        self.showErrorAlert(errorTitle: "Unsuccessful Login", errorMessage: "Please check your credentials and try again.")
                     }
                 }
             }
@@ -89,8 +89,8 @@ class LogInViewController: UIViewController {
      }
      */
     
-    func showErrorAlert(errorMessage: String) {
-        let alert = UIAlertController(title: "Oops!", message: errorMessage, preferredStyle: .alert)
+    func showErrorAlert(errorTitle: String, errorMessage: String) {
+        let alert = UIAlertController(title: errorTitle, message: errorMessage, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
         
         self.present(alert, animated: true, completion: nil)

--- a/Story Squad/Story Squad/View Controllers/SignupViewController.swift
+++ b/Story Squad/Story Squad/View Controllers/SignupViewController.swift
@@ -63,7 +63,7 @@ class SignupViewController: UIViewController {
         let validateErrorMessage = validateFields()
         
         if validateErrorMessage != nil {
-            showErrorAlert(errorMessage: validateErrorMessage!)
+            showErrorAlert(errorTitle: "Oops!", errorMessage: validateErrorMessage!)
             
         } else {
             
@@ -84,7 +84,7 @@ class SignupViewController: UIViewController {
                     do {
                         let result = try result.get()
                         self.bearerToken = result
-                        self.parentUser = self.networkingController.parentUser
+//                        self.parentUser = self.networkingController.parentUser
                         // let parentRepresentation = result
                         //print("Parent Representation result: \(String(describing: parentRepresentation))")
                         
@@ -95,15 +95,15 @@ class SignupViewController: UIViewController {
                                 self.parentUser = parent
                                 self.performSegue(withIdentifier: "ShowTabBarSegue", sender: self)
                             } else {
-                                self.showErrorAlert(errorMessage: "Timed out. Please try again")
-                                NSLog("Couldn't get response from server.")
+                                self.showErrorAlert(errorTitle: "Oops!", errorMessage: "Couldn't get all necessary data. Please try again")
+                                NSLog("Some of the data is not complete")
                             }
                         }
                     } catch {
                         print("Didn't get a succesfull Result")
                         
                         DispatchQueue.main.async {
-                            self.showErrorAlert(errorMessage: "Couldn't Sign up")
+                            self.showErrorAlert(errorTitle: "Signup unseccessful", errorMessage: "Please check your credentials and try again")
                         }
                     }
                 }
@@ -111,8 +111,8 @@ class SignupViewController: UIViewController {
         }
     }
     
-    func showErrorAlert(errorMessage: String) {
-        let alert = UIAlertController(title: "Oops!", message: errorMessage, preferredStyle: .alert)
+    func showErrorAlert(errorTitle: String, errorMessage: String) {
+        let alert = UIAlertController(title: errorTitle, message: errorMessage, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
         
         self.present(alert, animated: true, completion: nil)


### PR DESCRIPTION
# Description
User can't continue to DashboardVC if parentUser is not set

Fixes # (issue)
User now can't continue to DashboardVC from either SignupVC or LoginVC without setting the parentUser property first.
An alert will now pop up to suggest to the user to try again.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [ ] Complete, tested, ready to review and merge
- [x] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

- [ ] Test A
- [ ] Test B

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
